### PR TITLE
Consume route manifest from server build instead of context

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,100 +19,25 @@ npm install @nasa-gcn/remix-seo
 
 # Usage
 
-For all miscellaneous routes in root like `/robots.txt`, `/sitemap.xml`. We can create a single function to handle all of them instead polluting our `routes` folder.
+Add a sitemap and a robots.txt file to your site by adding [resource routes](https://remix.run/docs/en/main/guides/resource-routes) for them, as explained below.
 
-For that, lets create a file called `otherRootRoutes.server.ts` (file could be anything, make sure it is import only in server by ending with`.server.{ts|js}`)
+## Sitemap
+
+Add to your project a route moodule called `app/routes/sitemap[.]xml.ts` with the following contents.
 
 ```ts
-// otherRootRoutes.server.ts
+import { routes } from "@remix-run/dev/server-build";
+import type { LoaderArgs } from "@remix-run/node";
+import { generateSitemap } from "@nasa-gcn/remix-seo";
 
-import { EntryContext } from "remix";
-
-type Handler = (
-  request: Request,
-  remixContext: EntryContext
-) => Promise<Response | null> | null;
-
-export const otherRootRoutes: Record<string, Handler> = {};
-
-export const otherRootRouteHandlers: Array<Handler> = [
-  ...Object.entries(otherRootRoutes).map(([path, handler]) => {
-    return (request: Request, remixContext: EntryContext) => {
-      if (new URL(request.url).pathname !== path) return null;
-      return handler(request, remixContext);
-    };
-  }),
-];
-```
-
-and import this file in your `entry.server.tsx`
-
-```diff
-import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
-+import { otherRootRouteHandlers } from "./otherRootRoutes.server";
-
-export default async function handleRequest(
-  request: Request,
-  responseStatusCode: number,
-  responseHeaders: Headers,
-  remixContext: EntryContext
-) {
-+  for (const handler of otherRootRouteHandlers) {
-+    const otherRouteResponse = await handler(request, remixContext);
-+    if (otherRouteResponse) return otherRouteResponse;
-+  }
-  let markup = renderToString(
-    <RemixServer context={remixContext} url={request.url} />
-  );
-
-  responseHeaders.set("Content-Type", "text/html");
-
-  return new Response("<!DOCTYPE html>" + markup, {
-    status: responseStatusCode,
-    headers: responseHeaders,
+export function loader({ request }: LoaderArgs) {
+  return generateSitemap(request, routes, {
+    siteUrl: "https://balavishnuvj.com",
   });
 }
 ```
 
-## Sitemap
-
-To generate sitemap, `@nasa-gcn/remix-seo` would need context of all your routes.
-
-If you have already created a file to handle all root routes. If not, [check above](#usage)
-
-Add config for your sitemap
-
-```ts
-import { EntryContext } from "remix";
-import { generateSitemap } from "@nasa-gcn/remix-seo";
-
-type Handler = (
-  request: Request,
-  remixContext: EntryContext
-) => Promise<Response | null> | null;
-
-export const otherRootRoutes: Record<string, Handler> = {
-  "/sitemap.xml": async (request, remixContext) => {
-    return generateSitemap(request, remixContext, {
-      siteUrl: "https://balavishnuvj.com",
-    });
-  },
-};
-
-export const otherRootRouteHandlers: Array<Handler> = [
-  ...Object.entries(otherRootRoutes).map(([path, handler]) => {
-    return (request: Request, remixContext: EntryContext) => {
-      if (new URL(request.url).pathname !== path) return null;
-
-      return handler(request, remixContext);
-    };
-  }),
-];
-```
-
-`generateSitemap` takes three params `request`, `EntryContext`, and `SEOOptions`.
+`generateSitemap` takes three params `request`, `routes`, and `SEOOptions`.
 
 ### Configuration
 
@@ -163,15 +88,20 @@ export const handle: SEOHandle = {
 
 ## Robots
 
-You can add this part of the root routes as did above[check above](#usage). Or else you can create a new file in your `routes` folder with `robots[.txt].ts`
+Add a new route module with the filename `app/routes/robots[.txt].ts` and the
+following contents:
 
 To generate `robots.txt`
 
 ```ts
-generateRobotsTxt([
-  { type: "sitemap", value: "https://balavishnuvj.com/sitemap.xml" },
-  { type: "disallow", value: "/admin" },
-]);
+import { generateRobotsTxt } from '@nasa-gcn/remix-seo'
+
+export function loader() {
+  return generateRobotsTxt([
+    { type: "sitemap", value: "https://balavishnuvj.com/sitemap.xml" },
+    { type: "disallow", value: "/admin" },
+  ]);
+}
 ```
 
 `generateRobotsTxt` takes two arguments.
@@ -211,43 +141,4 @@ export type RobotsConfig = {
         },
   */
 };
-```
-
-If you are using single function to create both `sitemap` and `robots.txt`
-
-```ts
-import { EntryContext } from "remix";
-import { generateRobotsTxt, generateSitemap } from "@nasa-gcn/remix-seo";
-
-type Handler = (
-  request: Request,
-  remixContext: EntryContext
-) => Promise<Response | null> | null;
-
-export const otherRootRoutes: Record<string, Handler> = {
-  "/sitemap.xml": async (request, remixContext) => {
-    return generateSitemap(request, remixContext, {
-      siteUrl: "https://balavishnuvj.com",
-      headers: {
-        "Cache-Control": `public, max-age=${60 * 5}`,
-      },
-    });
-  },
-  "/robots.txt": async () => {
-    return generateRobotsTxt([
-      { type: "sitemap", value: "https://balavishnuvj.com/sitemap.xml" },
-      { type: "disallow", value: "/admin" },
-    ]);
-  },
-};
-
-export const otherRootRouteHandlers: Array<Handler> = [
-  ...Object.entries(otherRootRoutes).map(([path, handler]) => {
-    return (request: Request, remixContext: EntryContext) => {
-      if (new URL(request.url).pathname !== path) return null;
-
-      return handler(request, remixContext);
-    };
-  }),
-];
 ```

--- a/src/sitemap/index.ts
+++ b/src/sitemap/index.ts
@@ -1,16 +1,14 @@
-import { EntryContext } from "@remix-run/server-runtime";
+import type { ServerBuild } from "@remix-run/server-runtime";
 import { SEOOptions } from "../types";
 import { getSitemapXml } from "./utils";
 
 export async function generateSitemap(
   request: Request,
-  remixEntryContent: EntryContext,
+  routes: ServerBuild["routes"],
   options: SEOOptions
 ) {
   const { siteUrl, headers } = options;
-  const sitemap = await getSitemapXml(request, remixEntryContent, {
-    siteUrl,
-  });
+  const sitemap = await getSitemapXml(request, routes, { siteUrl });
   const bytes = new TextEncoder().encode(sitemap).byteLength
   
   return new Response(sitemap, {

--- a/src/sitemap/utils.ts
+++ b/src/sitemap/utils.ts
@@ -1,6 +1,6 @@
 // This is adapted from https://github.com/kentcdodds/kentcdodds.com
 
-import { EntryContext } from "@remix-run/server-runtime";
+import type { ServerBuild } from "@remix-run/server-runtime";
 import isEqual from "lodash/isEqual";
 import { SEOHandle, SitemapEntry } from "../types";
 
@@ -20,7 +20,7 @@ function removeTrailingSlash(s: string) {
 
 async function getSitemapXml(
   request: Request,
-  remixContext: EntryContext,
+  routes: ServerBuild["routes"],
   options: Options
 ) {
   const { siteUrl } = options;
@@ -43,7 +43,7 @@ async function getSitemapXml(
 
   const rawSitemapEntries = (
     await Promise.all(
-      Object.entries(remixContext.routeModules).map(async ([id, mod]) => {
+      Object.entries(routes).map(async ([id, { module: mod }]) => {
         if (id === "root") return;
 
         const handle = mod.handle as SEOHandle | undefined;
@@ -55,13 +55,13 @@ async function getSitemapXml(
         // (these are an opt-in via the getSitemapEntries method)
         if (!("default" in mod)) return;
 
-        const manifestEntry = remixContext.manifest.routes[id];
+        const manifestEntry = routes[id];
         if (!manifestEntry) {
           console.warn(`Could not find a manifest entry for ${id}`);
           return;
         }
         let parentId = manifestEntry.parentId;
-        let parent = parentId ? remixContext.manifest.routes[parentId] : null;
+        let parent = parentId ? routes[parentId] : null;
 
         let path;
         if (manifestEntry.path) {
@@ -79,7 +79,7 @@ async function getSitemapXml(
             : "";
           path = `${parentPath}/${path}`;
           parentId = parent.parentId;
-          parent = parentId ? remixContext.manifest.routes[parentId] : null;
+          parent = parentId ? routes[parentId] : null;
         }
 
         // we can't handle dynamic routes, so if the handle doesn't have a


### PR DESCRIPTION
Perhaps surprisingly, you can import the server build in any route module, like this:

```ts
import * as build from '@remix-run/dev/server-build'
import { useLoaderData } from '@remix-run/react'

export function loader() {
  return Object.keys(build.routes)
}

export default function () {
  const routes = useLoaderData<typeof loader>()
  return (
    <>
      <h1>List of routes</h1>
      <ul>
        {routes.map((route) => (
          <li key={route}>{route}</li>
        ))}
      </ul>
    </>
  )
}
```

As a result, customizing the Remix server entry point is not necessary.

See https://github.com/remix-run/remix/discussions/2912#discussioncomment-7013261

Addresses https://github.com/balavishnuvj/remix-seo/pull/14