### PR TITLE
fix double slash

### DIFF
--- a/src/sitemap/utils.ts
+++ b/src/sitemap/utils.ts
@@ -77,7 +77,7 @@ async function getSitemapXml(
           const parentPath = parent.path
             ? removeTrailingSlash(parent.path)
             : "";
-          path = `${parentPath}/${path}`;
+          path = `${parentPath}${path}`;
           parentId = parent.parentId;
           parent = parentId ? routes[parentId] : null;
         }


### PR DESCRIPTION
I've started to use your project to generate sitemap.xml for my remix app, and I've noticed that there is // in urls in generated sitemap. I had inlined all the code from your package into my project and found the place where double / sneaks in.

example of how it was:

```
<loc>https://exaple.com//sign-up-with-github</loc>
```

how it is fixed:

```
<loc>https://exaple.com/sign-up-with-github</loc>
```